### PR TITLE
Add support for fetching data that loads from the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ import InfiniteScroll from 'react-infinite-scroller';
 | `pageStart`      | `Object`      | `0`        | The number of the first page to load, With the default of `0`, the first page is `1`.|
 | `threshold`      | `Boolean`     | `250`      | The distance in pixels before the end of the items that will trigger a call to `loadMore`.|
 | `useWindow`      | `Boolean`     | `true`     | Add scroll listeners to the window, or else, the component's `parentNode`.|
+| `isReverse`      | `Boolean`     | `false`    | Whether new items should be loaded when user scrolls to the top of the scrollable area.|

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -50,18 +50,18 @@ var InfiniteScroll = function (_Component) {
     }, {
         key: 'render',
         value: function render() {
-            var _props = this.props;
-            var children = _props.children;
-            var element = _props.element;
-            var hasMore = _props.hasMore;
-            var initialLoad = _props.initialLoad;
-            var loader = _props.loader;
-            var loadMore = _props.loadMore;
-            var pageStart = _props.pageStart;
-            var threshold = _props.threshold;
-            var useWindow = _props.useWindow;
-
-            var props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'loader', 'loadMore', 'pageStart', 'threshold', 'useWindow']);
+            var _props = this.props,
+                children = _props.children,
+                element = _props.element,
+                hasMore = _props.hasMore,
+                initialLoad = _props.initialLoad,
+                loader = _props.loader,
+                loadMore = _props.loadMore,
+                pageStart = _props.pageStart,
+                threshold = _props.threshold,
+                useWindow = _props.useWindow,
+                isReverse = _props.isReverse,
+                props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'loader', 'loadMore', 'pageStart', 'threshold', 'useWindow', 'isReverse']);
 
             return _react2.default.createElement(element, props, children, hasMore && (loader || this._defaultLoader));
         }
@@ -82,9 +82,9 @@ var InfiniteScroll = function (_Component) {
             var offset = void 0;
             if (this.props.useWindow) {
                 var scrollTop = scrollEl.pageYOffset !== undefined ? scrollEl.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-                offset = this.calculateTopPosition(el) + el.offsetHeight - scrollTop - window.innerHeight;
+                if (this.props.isReverse) offset = scrollTop;else offset = this.calculateTopPosition(el) + el.offsetHeight - scrollTop - window.innerHeight;
             } else {
-                offset = el.scrollHeight - el.parentNode.scrollTop - el.parentNode.clientHeight;
+                if (this.props.isReverse) offset = el.parentNode.scrollTop;else offset = el.scrollHeight - el.parentNode.scrollTop - el.parentNode.clientHeight;
             }
 
             if (offset < Number(this.props.threshold)) {
@@ -150,7 +150,8 @@ InfiniteScroll.propTypes = {
     loadMore: _react.PropTypes.func.isRequired,
     pageStart: _react.PropTypes.number,
     threshold: _react.PropTypes.number,
-    useWindow: _react.PropTypes.bool
+    useWindow: _react.PropTypes.bool,
+    isReverse: _react.PropTypes.bool
 };
 InfiniteScroll.defaultProps = {
     element: 'div',
@@ -158,7 +159,8 @@ InfiniteScroll.defaultProps = {
     initialLoad: true,
     pageStart: 0,
     threshold: 250,
-    useWindow: true
+    useWindow: true,
+    isReverse: false
 };
 exports.default = InfiniteScroll;
 module.exports = exports['default'];

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -9,7 +9,8 @@ export default class InfiniteScroll extends Component {
         loadMore: PropTypes.func.isRequired,
         pageStart: PropTypes.number,
         threshold: PropTypes.number,
-        useWindow: PropTypes.bool
+        useWindow: PropTypes.bool,
+        isReverse: PropTypes.bool
     };
 
     static defaultProps = {
@@ -18,7 +19,8 @@ export default class InfiniteScroll extends Component {
         initialLoad: true,
         pageStart: 0,
         threshold: 250,
-        useWindow: true
+        useWindow: true,
+        isReverse: false
     };
 
     constructor(props) {
@@ -47,6 +49,7 @@ export default class InfiniteScroll extends Component {
             pageStart,
             threshold,
             useWindow,
+            isReverse,
             ...props
         } = this.props;
 
@@ -67,9 +70,15 @@ export default class InfiniteScroll extends Component {
         let offset;
         if(this.props.useWindow) {
             var scrollTop = (scrollEl.pageYOffset !== undefined) ? scrollEl.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-            offset = this.calculateTopPosition(el) + el.offsetHeight - scrollTop - window.innerHeight;
+            if (this.props.isReverse)
+                offset = scrollTop;
+            else
+                offset = this.calculateTopPosition(el) + el.offsetHeight - scrollTop - window.innerHeight;
         } else {
-            offset = el.scrollHeight - el.parentNode.scrollTop - el.parentNode.clientHeight;
+            if (this.props.isReverse)
+                offset = el.parentNode.scrollTop;
+            else
+                offset = el.scrollHeight - el.parentNode.scrollTop - el.parentNode.clientHeight;
         }
 
         if(offset < Number(this.props.threshold)) {


### PR DESCRIPTION
We use this in our application. This PR adds a "isReverse" property that causes the loadMore function to be called when the user scrolls to the top of the area rather than to the bottom. One downside with this is that the module user has to make sure that after new items are added to the top of area that the area is scrolled back down to the original position. Otherwise the loadMore function will be triggered repeatedly.