### PR TITLE
isReverse improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React Infinite Scroller
 [![npm](https://img.shields.io/npm/v/react-infinite-scroller.svg?style=flat-square)](https://www.npmjs.com/package/react-infinite-scroller)
 [![npm](https://img.shields.io/npm/l/react-infinite-scroller.svg?style=flat-square)](https://github.com/CassetteRocks/react-infinite-scroller/blob/master/LICENSE)
 
-Infinitely load content using a React Component. This fork maintains a simple, lightweight infinite scroll package that supports both `window` and scrollable elements.
+Infinitely load content and Inview sensor using a React Component. This fork maintains a simple, lightweight infinite scroll package that supports both `window` and scrollable elements.
 
 - [Demo](https://cassetterocks.github.io/react-infinite-scroller/demo/)
 - [Demo Source](https://github.com/CassetteRocks/react-infinite-scroller/blob/master/docs/src/index.js)
@@ -24,9 +24,10 @@ yarn add react-infinite-scroller
 ## How to use
 
 ```js
-import InfiniteScroll from 'react-infinite-scroller';
+import { InfiniteScroll, InviewSensor } from 'react-infinite-scroller';
 ```
 
+## InfiniteScroll
 ### Window scroll events
 
 ```js
@@ -56,7 +57,7 @@ import InfiniteScroll from 'react-infinite-scroller';
 </div>
 ```
 
-## Props
+### Props
 
 | Name             | Type          | Default    | Description|
 |:----             |:----          |:----       |:----|
@@ -69,3 +70,35 @@ import InfiniteScroll from 'react-infinite-scroller';
 | `threshold`      | `Number`     | `250`      | The distance in pixels before the end of the items that will trigger a call to `loadMore`.|
 | `useCapture`     | `Boolean`     | `false`     | Proxy to the `useCapture` option of the added event listeners.|
 | `useWindow`      | `Boolean`     | `true`     | Add scroll listeners to the window, or else, the component's `parentNode`.|
+
+## InviewSensor
+InviweSensor component notifies you when it goes in or out of the current viewport. InviewSensor component must be placed inside of InfiniteScroll component and it shares the same scrollable element.
+
+The scrollable element is passed to InviewSensor via its context of InfiniteScroll component. InviewSensor is inspired by [React Visibility Sensor](https://github.com/EugeneHlushko/react-visibility-sensor).
+
+### Example
+
+```js
+<InfiniteScroll
+    pageStart={0}
+    loadMore={loadFunc}
+    hasMore={true || false}
+    loader={<div className="loader">Loading ...</div>}
+>
+  {items.map((item)=>
+    <div>
+      some contents here.
+      <InviewSensor onChange={onChange} />
+    </div>
+  )}
+</InfiniteScroll>
+```
+
+### Props
+
+| Name             | Type          | Default    | Description|
+|:----             |:----          |:----       |:----|
+| `onChange`       | `Function`    | required   | callback for whenever the element changes from being within the window viewport or not. Function is called with 1 argument (isVisible: boolean) |
+| `active`         | `Boolean`     | `true`     | boolean flag for enabling / disabling the sensor. When active !== true the sensor will not fire the onChange callback. |
+
+

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -43,9 +43,28 @@ var InfiniteScroll = function (_Component) {
       this.attachScrollListener();
     }
   }, {
+    key: 'componentWillUpdate',
+    value: function componentWillUpdate() {
+      if (this.props.isReverse) {
+        var scrollEl = window;
+        if (this.props.useWindow === false) {
+          scrollEl = this.scrollComponent.parentNode;
+        }
+        this.scrollHeight = scrollEl.scrollHeight;
+        this.scrollTop = scrollEl.scrollTop;
+      }
+    }
+  }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate() {
       this.attachScrollListener();
+      if (this.props.isReverse) {
+        var scrollEl = window;
+        if (this.props.useWindow === false) {
+          scrollEl = this.scrollComponent.parentNode;
+        }
+        scrollEl.scrollTop = this.scrollTop + (scrollEl.scrollHeight - this.scrollHeight);
+      }
     }
   }, {
     key: 'componentWillUnmount',
@@ -149,7 +168,7 @@ var InfiniteScroll = function (_Component) {
         _this2.scrollComponent = node;
       };
 
-      return _react2.default.createElement(element, props, children, hasMore && (loader || this.defaultLoader));
+      return _react2.default.createElement(element, props, isReverse ? hasMore && (loader || this.defaultLoader) : children, isReverse ? children : hasMore && (loader || this.defaultLoader));
     }
   }]);
 

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -27,6 +27,15 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var InfiniteScroll = function (_Component) {
   _inherits(InfiniteScroll, _Component);
 
+  _createClass(InfiniteScroll, [{
+    key: 'getChildContext',
+    value: function getChildContext() {
+      return {
+        infiniteScrollComponent: this
+      };
+    }
+  }]);
+
   function InfiniteScroll(props) {
     _classCallCheck(this, InfiniteScroll);
 
@@ -40,6 +49,7 @@ var InfiniteScroll = function (_Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       this.pageLoaded = this.props.pageStart;
+      this.scrollWindow = this.props.useWindow === false ? this.scrollComponent.parentNode : window;
       this.attachScrollListener();
     }
   }, {
@@ -198,6 +208,9 @@ InfiniteScroll.defaultProps = {
   isReverse: false,
   useCapture: false,
   loader: null
+};
+InfiniteScroll.childContextTypes = {
+  infiniteScrollComponent: _propTypes2.default.object
 };
 exports.default = InfiniteScroll;
 module.exports = exports['default'];

--- a/dist/InviewSensor.js
+++ b/dist/InviewSensor.js
@@ -1,0 +1,131 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var InviewSensor = function (_React$Component) {
+  _inherits(InviewSensor, _React$Component);
+
+  function InviewSensor(props) {
+    _classCallCheck(this, InviewSensor);
+
+    var _this = _possibleConstructorReturn(this, (InviewSensor.__proto__ || Object.getPrototypeOf(InviewSensor)).call(this, props));
+
+    _this.state = {
+      isVisible: null,
+      visibilityRect: {}
+    };
+    _this.check = _.debounce(_this.check.bind(_this), 100);
+    return _this;
+  }
+
+  _createClass(InviewSensor, [{
+    key: 'componentDidMount',
+    value: function componentDidMount() {
+      this.context.infiniteScrollComponent.scrollWindow.addEventListener('scroll', this.check);
+    }
+  }, {
+    key: 'componentWillUnmount',
+    value: function componentWillUnmount() {
+      this.context.infiniteScrollComponent.scrollWindow.removeEventListener('scroll', this.check);
+    }
+  }, {
+    key: 'check',
+    value: function check() {
+      var el = _reactDom2.default.findDOMNode(this);
+      var rect = el.getBoundingClientRect();
+      var containmentRect = this.context.infiniteScrollComponent.scrollWindow.getBoundingClientRect();
+
+      var visibilityRect = {
+        top: rect.top >= containmentRect.top,
+        left: rect.left >= containmentRect.left,
+        bottom: rect.bottom <= containmentRect.bottom,
+        right: rect.right <= containmentRect.right
+      };
+
+      var fullVisible = visibilityRect.top && visibilityRect.left && visibilityRect.bottom && visibilityRect.right;
+
+      var partialVertical = rect.top >= containmentRect.top && rect.top <= containmentRect.bottom || rect.bottom >= containmentRect.top && rect.bottom <= containmentRect.bottom || rect.top <= containmentRect.top && rect.bottom >= containmentRect.bottom;
+
+      var partialHorizontal = rect.left >= containmentRect.left && rect.left <= containmentRect.right || rect.right >= containmentRect.left && rect.right <= containmentRect.right;
+
+      var partialVisible = partialVertical && partialHorizontal;
+
+      var isVisible = false;
+
+      // if element is fully visible, why care about partial visibility??
+      if (fullVisible !== true && this.props.partialVisibility) {
+        // so, if partial visibility is observed
+        // if we have minimum top visibility set by props, lets check, if it meets the passed value
+        // so if for instance element is at least 200px in viewport, then show it.
+        if (this.props.partialVisibility && this.props.minTopValue && partialVisible) {
+          isVisible = rect.top <= containmentRect.bottom - this.props.minTopValue;
+        } else {
+          // minTopValue was not passed, just give partial Result.
+          isVisible = partialVisible;
+        }
+      } else {
+        // Partial visibility is not required, just return fullVisibility value
+        isVisible = fullVisible;
+      }
+
+      // notify the parent when the value changes
+      if (this.state.isVisible !== isVisible) {
+        this.setState({
+          isVisible: isVisible,
+          visibilityRect: visibilityRect
+        });
+        this.props.onChange(isVisible, visibilityRect);
+      }
+
+      return this.state;
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react2.default.Children.only(this.props.children);
+    }
+  }]);
+
+  return InviewSensor;
+}(_react2.default.Component);
+
+InviewSensor.propTypes = {
+  onChange: _react2.default.PropTypes.func.isRequired,
+  active: _react2.default.PropTypes.bool,
+  partialVisibility: _react2.default.PropTypes.bool,
+  delay: _react2.default.PropTypes.number,
+  delayedCall: _react2.default.PropTypes.bool,
+  children: _react2.default.PropTypes.element,
+  minTopValue: _react2.default.PropTypes.number
+};
+InviewSensor.contextTypes = {
+  infiniteScrollComponent: _react2.default.PropTypes.object
+};
+InviewSensor.defaultProps = {
+  active: true,
+  partialVisibility: false,
+  minTopValue: false,
+  children: _react2.default.createElement('span')
+};
+exports.default = InviewSensor;
+module.exports = exports['default'];

--- a/index.js
+++ b/index.js
@@ -1,1 +1,4 @@
-module.exports = require('./dist/InfiniteScroll')
+module.exports = {
+  InfiniteScroll: require('./dist/InfiniteScroll'),
+  InviewSensor: require('./dist/InviewSensor'),
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/CassetteRocks/react-infinite-scroller.git"
   },
   "scripts": {
-    "build": "mkdir -p dist && babel src/InfiniteScroll.js --out-file dist/InfiniteScroll.js",
+    "build": "mkdir -p dist && babel src/InfiniteScroll.js --out-file dist/InfiniteScroll.js && babel src/InviewSensor.js --out-file dist/InviewSensor.js",
     "prepublish": "npm run build",
     "test": "nyc npm run spec",
     "spec": "_mocha -R spec ./test/test_helper.js --recursive test/*_test.js",

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -33,6 +33,16 @@ export default class InfiniteScroll extends Component {
     loader: null,
   };
 
+  static childContextTypes = {
+    infiniteScrollComponent: PropTypes.object,
+  };
+
+  getChildContext() {
+    return {
+      infiniteScrollComponent: this
+    }
+  }
+
   constructor(props) {
     super(props);
 
@@ -41,6 +51,7 @@ export default class InfiniteScroll extends Component {
 
   componentDidMount() {
     this.pageLoaded = this.props.pageStart;
+    this.scrollWindow = this.props.useWindow === false ? this.scrollComponent.parentNode : window;
     this.attachScrollListener();
   }
 

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -44,8 +44,26 @@ export default class InfiniteScroll extends Component {
     this.attachScrollListener();
   }
 
+  componentWillUpdate() {
+    if (this.props.isReverse) {
+      var scrollEl = window;
+      if (this.props.useWindow === false) {
+        scrollEl = this.scrollComponent.parentNode;
+      }
+      this.scrollHeight = scrollEl.scrollHeight;
+      this.scrollTop = scrollEl.scrollTop;
+    }
+  }
+
   componentDidUpdate() {
     this.attachScrollListener();
+    if (this.props.isReverse) {
+      var scrollEl = window;
+      if (this.props.useWindow === false) {
+        scrollEl = this.scrollComponent.parentNode;
+      }
+      scrollEl.scrollTop = this.scrollTop + (scrollEl.scrollHeight - this.scrollHeight);
+    }
   }
 
   componentWillUnmount() {
@@ -147,8 +165,8 @@ export default class InfiniteScroll extends Component {
     return React.createElement(
         element,
         props,
-        children,
-        hasMore && (loader || this.defaultLoader),
+        isReverse ? hasMore && (loader || this.defaultLoader) : children,
+        isReverse ? children : hasMore && (loader || this.defaultLoader),
     );
   }
 }

--- a/src/InviewSensor.js
+++ b/src/InviewSensor.js
@@ -1,0 +1,108 @@
+'use strict';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default class InviewSensor extends React.Component {
+  static propTypes = {
+    onChange: React.PropTypes.func.isRequired,
+    active: React.PropTypes.bool,
+    partialVisibility: React.PropTypes.bool,
+    delay: React.PropTypes.number,
+    delayedCall: React.PropTypes.bool,
+    children: React.PropTypes.element,
+    minTopValue: React.PropTypes.number
+  }
+
+  static contextTypes = {
+    infiniteScrollComponent: React.PropTypes.object,
+  }
+
+  static defaultProps = {
+    active: true,
+    partialVisibility: false,
+    minTopValue: false,
+    children: React.createElement('span')
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      isVisible: null,
+      visibilityRect: {}
+    };
+    this.check = _.debounce(this.check.bind(this), 100);
+  }
+
+  componentDidMount() {
+    this.context.infiniteScrollComponent.scrollWindow.addEventListener('scroll', this.check);
+  }
+
+  componentWillUnmount() {
+    this.context.infiniteScrollComponent.scrollWindow.removeEventListener('scroll', this.check);
+  }
+
+  check() {
+    var el = ReactDOM.findDOMNode(this);
+    var rect = el.getBoundingClientRect();
+    var containmentRect = this.context.infiniteScrollComponent.scrollWindow.getBoundingClientRect();
+
+    var visibilityRect = {
+      top: rect.top >= containmentRect.top,
+      left: rect.left >= containmentRect.left,
+      bottom: rect.bottom <= containmentRect.bottom,
+      right: rect.right <= containmentRect.right
+    };
+
+    var fullVisible = (
+      visibilityRect.top &&
+      visibilityRect.left &&
+      visibilityRect.bottom &&
+      visibilityRect.right
+    );
+
+    var partialVertical =
+      (rect.top >= containmentRect.top && rect.top <= containmentRect.bottom)
+      || (rect.bottom >= containmentRect.top && rect.bottom <= containmentRect.bottom)
+      || (rect.top <= containmentRect.top && rect.bottom >= containmentRect.bottom);
+
+    var partialHorizontal =
+      (rect.left >= containmentRect.left && rect.left <= containmentRect.right)
+      || (rect.right >= containmentRect.left && rect.right <= containmentRect.right);
+
+    var partialVisible = partialVertical && partialHorizontal;
+
+    var isVisible = false;
+
+    // if element is fully visible, why care about partial visibility??
+    if (fullVisible !== true && this.props.partialVisibility) {
+      // so, if partial visibility is observed
+      // if we have minimum top visibility set by props, lets check, if it meets the passed value
+      // so if for instance element is at least 200px in viewport, then show it.
+      if (this.props.partialVisibility && this.props.minTopValue && partialVisible) {
+        isVisible = rect.top <= (containmentRect.bottom - this.props.minTopValue);
+      } else {
+        // minTopValue was not passed, just give partial Result.
+        isVisible = partialVisible;
+      }
+    } else {
+      // Partial visibility is not required, just return fullVisibility value
+      isVisible = fullVisible;
+    }
+
+    // notify the parent when the value changes
+    if (this.state.isVisible !== isVisible) {
+      this.setState({
+        isVisible: isVisible,
+        visibilityRect: visibilityRect
+      });
+      this.props.onChange(isVisible, visibilityRect);
+    }
+
+    return this.state;
+  }
+
+  render() {
+    return React.Children.only(this.props.children);
+  }
+}


### PR DESCRIPTION
Infinite scroll with isReverse option, load more function is causing infinite loop at the beginning.
This PR is fix this problem by adjusting scroll position after content loaded not to cause infinite loop.

And also loader should be placed at the top of the page, not the bottom.

