### PR TITLE
Add src to distribution to allow custom distro

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
-src
 coverage
 test
 .nyc_output
 docs
-


### PR DESCRIPTION
I need to use the library in the browser, in a special build, however when rolling my own bundle, I noticed that the source is not included and it is actually not possible to build my own distribution without it.