### PR TITLE
New 'relativeElement' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ import InfiniteScroll from 'react-infinite-scroller';
 | `threshold`      | `Number`     | `250`      | The distance in pixels before the end of the items that will trigger a call to `loadMore`.|
 | `useCapture`     | `Boolean`     | `false`     | Proxy to the `useCapture` option of the added event listeners.|
 | `useWindow`      | `Boolean`     | `true`     | Add scroll listeners to the window, or else, the component's `parentNode`.|
-| `relativeElement`| `String`     |            | Add scroll listeners to the relative parent dom element. overrides `useWindow`
+| `relativeElement`| `String`     |            | Add scroll listeners to the relative parent HTML Element. if defeined, overrides `useWindow`

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ import InfiniteScroll from 'react-infinite-scroller';
 | `threshold`      | `Number`     | `250`      | The distance in pixels before the end of the items that will trigger a call to `loadMore`.|
 | `useCapture`     | `Boolean`     | `false`     | Proxy to the `useCapture` option of the added event listeners.|
 | `useWindow`      | `Boolean`     | `true`     | Add scroll listeners to the window, or else, the component's `parentNode`.|
+| `relativeElement`| `String`     |            | Add scroll listeners to the relative parent dom element. overrides `useWindow`

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -64,7 +64,9 @@ var InfiniteScroll = function (_Component) {
     key: 'detachScrollListener',
     value: function detachScrollListener() {
       var scrollEl = window;
-      if (this.props.useWindow === false) {
+      if (this.props.relativeElement) {
+        scrollEl = this.props.relativeElement;
+      } else if (this.props.useWindow === false) {
         scrollEl = this.scrollComponent.parentNode;
       }
 
@@ -79,7 +81,9 @@ var InfiniteScroll = function (_Component) {
       }
 
       var scrollEl = window;
-      if (this.props.useWindow === false) {
+      if (this.props.relativeElement) {
+        scrollEl = this.props.relativeElement;
+      } else if (this.props.useWindow === false) {
         scrollEl = this.scrollComponent.parentNode;
       }
 
@@ -97,7 +101,13 @@ var InfiniteScroll = function (_Component) {
       var scrollEl = window;
 
       var offset = void 0;
-      if (this.props.useWindow) {
+      if (this.props.relativeElement) {
+        if (this.props.isReverse) {
+          offset = this.props.relativeElement;
+        } else {
+          offset = el.scrollHeight - this.props.relativeElement.scrollTop - this.props.relativeElement.clientHeight;
+        }
+      } else if (this.props.useWindow) {
         var scrollTop = scrollEl.pageYOffset !== undefined ? scrollEl.pageYOffset : (document.documentElement || document.body.parentNode || document.body).scrollTop;
         if (this.props.isReverse) {
           offset = scrollTop;
@@ -143,7 +153,8 @@ var InfiniteScroll = function (_Component) {
           threshold = _props.threshold,
           useCapture = _props.useCapture,
           useWindow = _props.useWindow,
-          props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'isReverse', 'loader', 'loadMore', 'pageStart', 'threshold', 'useCapture', 'useWindow']);
+          relativeElement = _props.relativeElement,
+          props = _objectWithoutProperties(_props, ['children', 'element', 'hasMore', 'initialLoad', 'isReverse', 'loader', 'loadMore', 'pageStart', 'threshold', 'useCapture', 'useWindow', 'relativeElement']);
 
       props.ref = function (node) {
         _this2.scrollComponent = node;
@@ -174,6 +185,7 @@ InfiniteScroll.propTypes = {
   threshold: _propTypes2.default.number,
   useCapture: _propTypes2.default.bool,
   useWindow: _propTypes2.default.bool,
+  relativeElement: _propTypes2.default.string,
   children: _propTypes2.default.oneOfType([_propTypes2.default.object, _propTypes2.default.array]).isRequired,
   loader: _propTypes2.default.object
 };
@@ -186,7 +198,8 @@ InfiniteScroll.defaultProps = {
   useWindow: true,
   isReverse: false,
   useCapture: false,
-  loader: null
+  loader: null,
+  relativeElement: null
 };
 exports.default = InfiniteScroll;
 module.exports = exports['default'];

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -185,7 +185,7 @@ InfiniteScroll.propTypes = {
   threshold: _propTypes2.default.number,
   useCapture: _propTypes2.default.bool,
   useWindow: _propTypes2.default.bool,
-  relativeElement: _propTypes2.default.string,
+  relativeElement: _propTypes2.default.object,
   children: _propTypes2.default.oneOfType([_propTypes2.default.object, _propTypes2.default.array]).isRequired,
   loader: _propTypes2.default.object
 };

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -14,7 +14,7 @@ export default class InfiniteScroll extends Component {
     threshold: PropTypes.number,
     useCapture: PropTypes.bool,
     useWindow: PropTypes.bool,
-    relativeElement: PropTypes.string,
+    relativeElement: PropTypes.object,
     children: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.array,

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -14,6 +14,7 @@ export default class InfiniteScroll extends Component {
     threshold: PropTypes.number,
     useCapture: PropTypes.bool,
     useWindow: PropTypes.bool,
+    relativeElement: PropTypes.string,
     children: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.array,
@@ -31,6 +32,7 @@ export default class InfiniteScroll extends Component {
     isReverse: false,
     useCapture: false,
     loader: null,
+    relativeElement: null
   };
 
   constructor(props) {
@@ -59,7 +61,9 @@ export default class InfiniteScroll extends Component {
 
   detachScrollListener() {
     let scrollEl = window;
-    if (this.props.useWindow === false) {
+    if (this.props.relativeElement) {
+      scrollEl = this.props.relativeElement;
+    } else if (this.props.useWindow === false) {
       scrollEl = this.scrollComponent.parentNode;
     }
 
@@ -73,7 +77,9 @@ export default class InfiniteScroll extends Component {
     }
 
     let scrollEl = window;
-    if (this.props.useWindow === false) {
+    if (this.props.relativeElement) {
+      scrollEl = this.props.relativeElement;
+    } else if (this.props.useWindow === false) {
       scrollEl = this.scrollComponent.parentNode;
     }
 
@@ -90,7 +96,13 @@ export default class InfiniteScroll extends Component {
     const scrollEl = window;
 
     let offset;
-    if (this.props.useWindow) {
+    if (this.props.relativeElement) {
+     if (this.props.isReverse) {
+        offset = this.props.relativeElement
+      } else {
+        offset = el.scrollHeight - this.props.relativeElement.scrollTop - this.props.relativeElement.clientHeight;
+      }
+    } else if (this.props.useWindow) {
       const scrollTop = (scrollEl.pageYOffset !== undefined) ?
        scrollEl.pageYOffset :
        (document.documentElement || document.body.parentNode || document.body).scrollTop;
@@ -137,6 +149,7 @@ export default class InfiniteScroll extends Component {
       threshold,
       useCapture,
       useWindow,
+      relativeElement,
       ...props
     } = this.props;
 

--- a/test/infiniteScroll_test.js
+++ b/test/infiniteScroll_test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { expect } from 'chai';
-import { stub, spy } from 'sinon';
+import {mount} from 'enzyme';
+import {expect} from 'chai';
+import {stub, spy} from 'sinon';
 import InfiniteScroll from '../src/InfiniteScroll';
 
 describe('InfiniteScroll component', () => {


### PR DESCRIPTION
Was trying to use React-Custom-Scroll package. 
infinite scroll listens to scroll of parent element or window. but custom-scroll's scroll is 2 levels up. and its scroll didn't call `loadMore` function. this way you can define the parent yourself.