### PR TITLE
Add detachScrollListener in componentDidUpdate

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -46,6 +46,7 @@ export default class InfiniteScroll extends Component {
   }
 
   componentDidUpdate() {
+    this.detachScrollListener();
     this.attachScrollListener();
   }
 


### PR DESCRIPTION
'react-infinite-scroll' is a good component.
But I think there is an issue.

Call the detachScrollListener function only when 'offset' is less than 'threshold' in the scrollListener function.
So when 'hasMore' changes, the detachScrollListener function is not called.
That's why I think the function detachScrollListener should be called in the componentDidUpdate function as well.