### PR TITLE
jsnext:main path can't found.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-src
 coverage
 test
 .nyc_output


### PR DESCRIPTION
jsnext:main path can't found.