### PR TITLE
Make mousewheel listener 'passive' to improve scrolling performance

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -179,6 +179,7 @@ var InfiniteScroll = (function(_Component) {
           'mousewheel',
           this.mousewheelListener,
           this.props.useCapture,
+          { passive: true },
         );
         scrollEl.addEventListener(
           'scroll',
@@ -193,16 +194,6 @@ var InfiniteScroll = (function(_Component) {
 
         if (this.props.initialLoad) {
           this.scrollListener();
-        }
-      },
-    },
-    {
-      key: 'mousewheelListener',
-      value: function mousewheelListener(e) {
-        // Prevents Chrome hangups
-        // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
-        if (e.deltaY === 1) {
-          e.preventDefault();
         }
       },
     },

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -101,6 +101,7 @@ export default class InfiniteScroll extends Component {
       'mousewheel',
       this.mousewheelListener,
       this.props.useCapture,
+      { passive: true },
     );
     scrollEl.addEventListener(
       'scroll',
@@ -115,14 +116,6 @@ export default class InfiniteScroll extends Component {
 
     if (this.props.initialLoad) {
       this.scrollListener();
-    }
-  }
-
-  mousewheelListener(e) {
-    // Prevents Chrome hangups
-    // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
-    if (e.deltaY === 1) {
-      e.preventDefault();
     }
   }
 


### PR DESCRIPTION
Chrome gives the following warning in the console:
```[Violation] Added non-passive event listener to a scroll-blocking 'mousewheel' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952```