### PR TITLE
feat(resize): listen for resize on window only (since it is not suppo…

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -156,7 +156,7 @@ var InfiniteScroll = (function(_Component) {
           this.scrollListener,
           this.props.useCapture,
         );
-        scrollEl.removeEventListener(
+        window.removeEventListener(
           'resize',
           this.scrollListener,
           this.props.useCapture,
@@ -185,7 +185,7 @@ var InfiniteScroll = (function(_Component) {
           this.scrollListener,
           this.props.useCapture,
         );
-        scrollEl.addEventListener(
+        window.addEventListener(
           'resize',
           this.scrollListener,
           this.props.useCapture,

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -80,7 +80,7 @@ export default class InfiniteScroll extends Component {
       this.scrollListener,
       this.props.useCapture,
     );
-    scrollEl.removeEventListener(
+    window.removeEventListener(
       'resize',
       this.scrollListener,
       this.props.useCapture,
@@ -107,7 +107,7 @@ export default class InfiniteScroll extends Component {
       this.scrollListener,
       this.props.useCapture,
     );
-    scrollEl.addEventListener(
+    window.addEventListener(
       'resize',
       this.scrollListener,
       this.props.useCapture,


### PR DESCRIPTION
Since resize event is not supported on elements other than window, we should always listen for this event on the window element (also when not using useWindow)