### PR TITLE
Change proptypes intended for rendering react elements to node

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -317,15 +317,12 @@ var InfiniteScroll = (function(_Component) {
 })(_react.Component);
 
 InfiniteScroll.propTypes = {
-  children: _propTypes2.default.oneOfType([
-    _propTypes2.default.object,
-    _propTypes2.default.array,
-  ]).isRequired,
+  children: _propTypes2.default.node.isRequired,
   element: _propTypes2.default.string,
   hasMore: _propTypes2.default.bool,
   initialLoad: _propTypes2.default.bool,
   isReverse: _propTypes2.default.bool,
-  loader: _propTypes2.default.object,
+  loader: _propTypes2.default.node,
   loadMore: _propTypes2.default.func.isRequired,
   pageStart: _propTypes2.default.number,
   ref: _propTypes2.default.func,

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -3,13 +3,12 @@ import PropTypes from 'prop-types';
 
 export default class InfiniteScroll extends Component {
   static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
-      .isRequired,
+    children: PropTypes.node.isRequired,
     element: PropTypes.string,
     hasMore: PropTypes.bool,
     initialLoad: PropTypes.bool,
     isReverse: PropTypes.bool,
-    loader: PropTypes.object,
+    loader: PropTypes.node,
     loadMore: PropTypes.func.isRequired,
     pageStart: PropTypes.number,
     ref: PropTypes.func,


### PR DESCRIPTION
From https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes

```
// Anything that can be rendered: numbers, strings, elements or an array
// (or fragment) containing these types.
optionalNode: PropTypes.node,
```

It seems like `node` would be a better proptype.