### PR TITLE
Correct property type in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -127,7 +127,7 @@
                 </tr>
                 <tr>
                     <td><code>threshold</code></td>
-                    <td><code>Boolean</code></td>
+                    <td><code>Number</code></td>
                     <td><code>250</code></td>
                     <td>The distance in pixels before the end of the items that will trigger a call to <code>loadMore</code>.</td>
                 </tr>


### PR DESCRIPTION
The current GitHub page lists the offset property as a Boolean, however this is a Number, as shown in the docs. 

This PR addresses this small issue by correcting the property type.