### PR TITLE
Safely navigate a null scroll component (offsetHeight of null)

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -166,7 +166,7 @@ var InfiniteScroll = (function(_Component) {
     {
       key: 'getParentElement',
       value: function getParentElement(el) {
-        return el.parentNode;
+        return el && el.parentNode;
       },
     },
     {
@@ -241,9 +241,7 @@ var InfiniteScroll = (function(_Component) {
           if (this.props.isReverse) {
             offset = scrollTop;
           } else {
-            offset =
-              this.calculateTopPosition(el) +
-              (el.offsetHeight - scrollTop - window.innerHeight);
+            offset = this.calculateOffset(el, scrollTop);
           }
         } else if (this.props.isReverse) {
           offset = parentNode.scrollTop;
@@ -253,13 +251,30 @@ var InfiniteScroll = (function(_Component) {
         }
 
         // Here we make sure the element is visible as well as checking the offset
-        if (offset < Number(this.props.threshold) && el.offsetParent !== null) {
+        if (
+          offset < Number(this.props.threshold) &&
+          el &&
+          el.offsetParent !== null
+        ) {
           this.detachScrollListener();
           // Call loadMore after detachScrollListener to allow for non-async loadMore functions
           if (typeof this.props.loadMore === 'function') {
             this.props.loadMore((this.pageLoaded += 1));
           }
         }
+      },
+    },
+    {
+      key: 'calculateOffset',
+      value: function calculateOffset(el, scrollTop) {
+        if (!el) {
+          return 0;
+        }
+
+        return (
+          this.calculateTopPosition(el) +
+          (el.offsetHeight - scrollTop - window.innerHeight)
+        );
       },
     },
     {

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -87,7 +87,7 @@ export default class InfiniteScroll extends Component {
   }
 
   getParentElement(el) {
-    return el.parentNode;
+    return el && el.parentNode;
   }
 
   filterProps(props) {
@@ -149,9 +149,7 @@ export default class InfiniteScroll extends Component {
       if (this.props.isReverse) {
         offset = scrollTop;
       } else {
-        offset =
-          this.calculateTopPosition(el) +
-          (el.offsetHeight - scrollTop - window.innerHeight);
+        offset = this.calculateOffset(el, scrollTop);
       }
     } else if (this.props.isReverse) {
       offset = parentNode.scrollTop;
@@ -160,13 +158,27 @@ export default class InfiniteScroll extends Component {
     }
 
     // Here we make sure the element is visible as well as checking the offset
-    if (offset < Number(this.props.threshold) && el.offsetParent !== null) {
+    if (
+      offset < Number(this.props.threshold) &&
+      (el && el.offsetParent !== null)
+    ) {
       this.detachScrollListener();
       // Call loadMore after detachScrollListener to allow for non-async loadMore functions
       if (typeof this.props.loadMore === 'function') {
         this.props.loadMore((this.pageLoaded += 1));
       }
     }
+  }
+
+  calculateOffset(el, scrollTop) {
+    if (!el) {
+      return 0;
+    }
+
+    return (
+      this.calculateTopPosition(el) +
+      (el.offsetHeight - scrollTop - window.innerHeight)
+    );
   }
 
   calculateTopPosition(el) {

--- a/test/infiniteScroll_test.js
+++ b/test/infiniteScroll_test.js
@@ -75,4 +75,28 @@ describe('InfiniteScroll component', () => {
     InfiniteScroll.prototype.attachScrollListener.restore();
     InfiniteScroll.prototype.scrollListener.restore();
   });
+
+  it('should handle when the scrollElement is removed from the DOM', () => {
+    const loadMore = stub();
+
+    const wrapper = mount(
+      <div>
+        <InfiniteScroll pageStart={0} loadMore={loadMore} hasMore={false}>
+          <div className="child-component">Child Text</div>
+        </InfiniteScroll>
+      </div>,
+    );
+
+    const component = wrapper.find(InfiniteScroll);
+
+    // The component has now mounted, but the scrollComponent is null
+    component.instance().scrollComponent = null;
+
+    // Invoke the scroll listener which depends on the scrollComponent to
+    // verify it executes properly, and safely navigates when the
+    // scrollComponent is null.
+    component.instance().scrollListener();
+
+    expect(wrapper.text()).to.contain('Child Text');
+  });
 });


### PR DESCRIPTION
**Issue**: https://github.com/CassetteRocks/react-infinite-scroller/issues/147

We've been running into these errors: 
- `Cannot read property 'offsetHeight' of null`
- `null is not an object (evaluating 'el.offsetHeight')`

The problem appears to be that `el` (which is equivalent to `this.scrollComponent`) is `null`. This is odd because it seems as if the `ref` for the element in `render` no longer exists, but the scroll event is still fired (which is removed in `componentWillUnmount`). We weren't able to get any more information, but by safely navigating the `el` (`this.srollComponent`) it appeared to fix the issue without any user facing impact. Based on the linked issue, it seems others are also running into this problem?

A test case was added to simulate this scenario, but required reaching into the internals. Let me know if it's better to remove it altogether?

This is data for this error over several days, measured in thousands. We forked this repository and [tried this patch](https://github.com/joinhandshake/react-infinite-scroller/pull/1/files) for a week and this seems to resolve this specific issue.
![example](https://user-images.githubusercontent.com/5247455/44439208-84a69100-a577-11e8-8ef1-3b8656d77beb.png)
