### PR TITLE
ignore .bablerc when publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@ coverage
 test
 .nyc_output
 docs
-
+.babelrc


### PR DESCRIPTION
This will fix the issue raised in [#99](https://github.com/CassetteRocks/react-infinite-scroller/issues/99 ):

Module build failed: ReferenceError: Unknown plugin "add-module-exports" specified in react-infinite-scroller/.babelrc