### PR TITLE
Fixed React 16 console error due to invalid DOM attribute when passing through scrollParent

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,27 +61,20 @@ import InfiniteScroll from 'react-infinite-scroller';
 You can define a custom `parentNode` element to base the scroll calulations on.
 
 ```
-class InfiniteScrollOverride extends InfiniteScroll {
-
-    /**
-     * We are overriding the getParentElement function to use a custom element as the scrollable element
-     *
-     * @param {any} el the scroller domNode
-     * @returns {any} the parentNode to base the scroll calulations on
-     *
-     * @memberOf InfiniteScrollOverride
-     */
-    getParentElement(el) {
-        if (this.props.scrollParent) {
-            return this.props.scrollParent;
-        }
-        return super.getParentElement(el);
-    }
-
-    render() {
-        return super.render();
-    }
-}
+<div style="height:700px;overflow:auto;" ref={(ref) => this.scrollParentRef = ref}>
+    <div>
+        <InfiniteScroll
+            pageStart={0}
+            loadMore={loadFunc}
+            hasMore={true || false}
+            loader={<div className="loader" key={0}>Loading ...</div>}
+            useWindow={false}
+            scrollParent={this.scrollParentRef}
+        >
+            {items}
+        </InfiniteScroll>
+    </div>
+</div>
 ```
 
 ## Props
@@ -95,6 +88,7 @@ class InfiniteScrollOverride extends InfiniteScroll {
 | `loadMore`       | `Function`    |            | A callback when more items are requested by the user. Receives a single parameter specifying the page to load e.g. `function handleLoadMore(page) { /* load more items here */ }` }|
 | `loader`         | `Component`   |            | A React component to render while more items are loading. The parent component must have a unique key prop. |
 | `pageStart`      | `Number`      | `0`        | The number of the first page to load, With the default of `0`, the first page is `1`.|
+| `scrollParent`   | `React.Element`|           | Override for the scroll listener to attach to if not the immediate parent. |
 | `threshold`      | `Number`     | `250`      | The distance in pixels before the end of the items that will trigger a call to `loadMore`.|
 | `useCapture`     | `Boolean`     | `false`     | Proxy to the `useCapture` option of the added event listeners.|
 | `useWindow`      | `Boolean`     | `true`     | Add scroll listeners to the window, or else, the component's `parentNode`.|

--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -166,6 +166,10 @@ var InfiniteScroll = (function(_Component) {
     {
       key: 'getParentElement',
       value: function getParentElement(el) {
+        var scrollParent = this.props.scrollParent;
+        if (scrollParent != null) {
+          return scrollParent;
+        }
         return el && el.parentNode;
       },
     },
@@ -178,16 +182,15 @@ var InfiniteScroll = (function(_Component) {
     {
       key: 'attachScrollListener',
       value: function attachScrollListener() {
-        if (
-          !this.props.hasMore ||
-          !this.getParentElement(this.scrollComponent)
-        ) {
+        var parentElement = this.getParentElement(this.scrollComponent);
+
+        if (!this.props.hasMore || !parentElement) {
           return;
         }
 
         var scrollEl = window;
         if (this.props.useWindow === false) {
-          scrollEl = this.getParentElement(this.scrollComponent);
+          scrollEl = parentElement;
         }
 
         scrollEl.addEventListener(
@@ -357,6 +360,7 @@ InfiniteScroll.propTypes = {
   loadMore: _propTypes2.default.func.isRequired,
   pageStart: _propTypes2.default.number,
   ref: _propTypes2.default.func,
+  scrollParent: _propTypes2.default.element,
   threshold: _propTypes2.default.number,
   useCapture: _propTypes2.default.bool,
   useWindow: _propTypes2.default.bool,
@@ -372,6 +376,7 @@ InfiniteScroll.defaultProps = {
   isReverse: false,
   useCapture: false,
   loader: null,
+  scrollParent: null,
 };
 exports.default = InfiniteScroll;
 module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinite-scroller",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Infinite scroll component for React in ES6",
   "main": "index.js",
   "jsnext:main": "src/InfiniteScroll.js",

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -211,6 +211,7 @@ export default class InfiniteScroll extends Component {
       threshold,
       useCapture,
       useWindow,
+      scrollParent,
       ...props
     } = renderProps;
 

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -12,6 +12,7 @@ export default class InfiniteScroll extends Component {
     loadMore: PropTypes.func.isRequired,
     pageStart: PropTypes.number,
     ref: PropTypes.func,
+    scrollParent: PropTypes.element,
     threshold: PropTypes.number,
     useCapture: PropTypes.bool,
     useWindow: PropTypes.bool,
@@ -28,6 +29,7 @@ export default class InfiniteScroll extends Component {
     isReverse: false,
     useCapture: false,
     loader: null,
+    scrollParent: null,
   };
 
   constructor(props) {
@@ -87,6 +89,10 @@ export default class InfiniteScroll extends Component {
   }
 
   getParentElement(el) {
+    const scrollParent = this.props.scrollParent;
+    if (scrollParent != null) {
+      return scrollParent;
+    }
     return el && el.parentNode;
   }
 
@@ -95,13 +101,15 @@ export default class InfiniteScroll extends Component {
   }
 
   attachScrollListener() {
-    if (!this.props.hasMore || !this.getParentElement(this.scrollComponent)) {
+    const parentElement = this.getParentElement(this.scrollComponent);
+
+    if (!this.props.hasMore || !parentElement) {
       return;
     }
 
     let scrollEl = window;
     if (this.props.useWindow === false) {
-      scrollEl = this.getParentElement(this.scrollComponent);
+      scrollEl = parentElement;
     }
 
     scrollEl.addEventListener(


### PR DESCRIPTION
Fixed https://github.com/CassetteRocks/react-infinite-scroller/issues/177

This change adds a new prop so the caller can pass through the `scrollParent` element instead of creating a subcomponent. The old code will still work as it did before and I tested this with the demo site on this website.