### PR TITLE
Prevent extra calls to isPassiveSupported

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -265,7 +265,7 @@ var InfiniteScroll = (function(_Component) {
       value: function mousewheelListener(e) {
         // Prevents Chrome hangups
         // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
-        if (e.deltaY === 1 && !this.isPassiveSupported()) {
+        if (e.deltaY === 1 && !this.options.passive) {
           e.preventDefault();
         }
       }

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -178,7 +178,7 @@ export default class InfiniteScroll extends Component {
   mousewheelListener(e) {
     // Prevents Chrome hangups
     // See: https://stackoverflow.com/questions/47524205/random-high-content-download-time-in-chrome/47684257#47684257
-    if (e.deltaY === 1 && !this.isPassiveSupported()) {
+    if (e.deltaY === 1 && !this.options.passive) {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
Currently, `isPassiveSupported` is potentially called for every call of `mousewheelListener`. The result of `isPassiveSupported` is stored during `componentDidMount` and is unlikely to change, so we can just check the result without calling it again. 