### PR TITLE
Fixed a vertical scrolling warning that occurred in Google Chrome.

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -89,6 +89,10 @@ export default class InfiniteScroll extends Component {
         useCapture: this.props.useCapture,
         passive: true
       };
+    } else {
+      options = {
+        passive: false
+      };
     }
     return options;
   }


### PR DESCRIPTION
Fixes [#212](https://github.com/CassetteRocks/react-infinite-scroller/issues/212)

Fixed the warning by explicitly specifying passive.