### PR TITLE
Scroll to top fixed

### DIFF
--- a/dist/InfiniteScroll.js
+++ b/dist/InfiniteScroll.js
@@ -113,8 +113,11 @@ var InfiniteScroll = (function(_Component) {
     {
       key: 'componentDidUpdate',
       value: function componentDidUpdate() {
+        var parentElement = this.getParentElement(this.scrollComponent);
+        if (this.props.pageStart === 0) {
+          parentElement.scrollTop = 0;
+        }
         if (this.props.isReverse && this.loadMore) {
-          var parentElement = this.getParentElement(this.scrollComponent);
           parentElement.scrollTop =
             parentElement.scrollHeight -
             this.beforeScrollHeight +
@@ -160,6 +163,10 @@ var InfiniteScroll = (function(_Component) {
           options = {
             useCapture: this.props.useCapture,
             passive: true
+          };
+        } else {
+          options = {
+            passive: false
           };
         }
         return options;

--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -47,8 +47,11 @@ export default class InfiniteScroll extends Component {
   }
 
   componentDidUpdate() {
+    const parentElement = this.getParentElement(this.scrollComponent);
+    if (this.props.pageStart === 0) {
+      parentElement.scrollTop = 0;
+    }
     if (this.props.isReverse && this.loadMore) {
-      const parentElement = this.getParentElement(this.scrollComponent);
       parentElement.scrollTop =
         parentElement.scrollHeight -
         this.beforeScrollHeight +


### PR DESCRIPTION
If pageStart is zero then the scroller should be scrolled back to the top.
Currently what is does is, it scrolls back to the same position after the state is updated in redux.