### PR TITLE
Fix handling of resize event

### DIFF
--- a/src/InfiniteScroll.js
+++ b/src/InfiniteScroll.js
@@ -126,7 +126,7 @@ export default class InfiniteScroll extends Component {
       this.scrollListener,
       this.options ? this.options : this.props.useCapture
     );
-    scrollEl.removeEventListener(
+    window.removeEventListener(
       'resize',
       this.scrollListener,
       this.options ? this.options : this.props.useCapture
@@ -168,7 +168,7 @@ export default class InfiniteScroll extends Component {
       this.scrollListener,
       this.options ? this.options : this.props.useCapture
     );
-    scrollEl.addEventListener(
+    window.addEventListener(
       'resize',
       this.scrollListener,
       this.options ? this.options : this.props.useCapture


### PR DESCRIPTION
`resize` events are only fired on the `window` object so the listener need to be registered on the `window` object.